### PR TITLE
support injecting wgServer via ENV

### DIFF
--- a/xlpsystem/mediawiki/xlp_data/LocalSettings.php
+++ b/xlpsystem/mediawiki/xlp_data/LocalSettings.php
@@ -30,7 +30,7 @@ $wgMetaNamespace = "Mem_201801_toyhouse";
 $wgScriptPath = "";
 
 ## The protocol and server name to use in fully-qualified URLs
-$wgServer = "http://hotbackup.toyhouse.cc:801";
+$wgServer = "SERVER_URL";
 
 ## The URL path to static resources (images, scripts, etc.)
 $wgResourceBasePath = $wgScriptPath;

--- a/xlpsystem/mediawiki/xlp_start.sh
+++ b/xlpsystem/mediawiki/xlp_start.sh
@@ -17,6 +17,13 @@ sed -i --follow-symlinks '$ a \$wgDisableSearchUpdate = true;' $MW_INSTALL_PATH/
 # Generate Elasticsearch index
 php $MW_INSTALL_PATH/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php
 
+# Inject $wgServer
+if [ -z "$SERVER_URL" ] 
+then 
+  SERVER_URL="http:\/\/hotbackup.toyhouse.cc:801"
+fi
+sed -i --follow-symlinks "s/SERVER_URL/${SERVER_URL}/g" $MW_INSTALL_PATH/LocalSettings.php
+
 # Remove $wgDisableSearchUpdate from LocalSettings.php
 sed -i --follow-symlinks '/\$wgDisableSearchUpdate = true;/d' $MW_INSTALL_PATH/LocalSettings.php
 


### PR DESCRIPTION
Test:

```
 docker run -it mediawiki bash  
```
```
root@fb883d8da8d3:/var/www/html# grep wgServer LocalSettings.php 
$wgServer = "http://hotbackup.toyhouse.cc:801";
```

```
docker run -e "SERVER_URL=http:\/\/www.google.com" -it mediawiki bash
```
```
root@246f4e700951:/var/www/html# grep wgServer LocalSettings.php 
$wgServer = "http://www.google.com";
```